### PR TITLE
docs: fix typo in design document

### DIFF
--- a/src/agent/nextgen/DESIGN.md
+++ b/src/agent/nextgen/DESIGN.md
@@ -44,7 +44,7 @@ The NextGen agent architecture is designed for **long-running autonomous coding 
 - Learn from past work to improve code quality
 - Keep humans informed without requiring constant attention
 - **Resume from any point with full context** (domain memory)
-- **Verify progress through tests and a seperate review agent, not the implementing agent claims** (test-bound status)
+- **Verify progress through tests and a separate review agent, not the implementing agent claims** (test-bound status)
 
 ### Example Use Case
 


### PR DESCRIPTION
## Summary
- fix a spelling typo in the next-generation agent design document

## Testing
- Not run (documentation-only change)